### PR TITLE
JTable getFields cache fix

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -225,16 +225,18 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	/**
 	 * Get the columns from database table.
 	 *
+	 * @param   bool  $reload  flag to reload cache
+	 *
 	 * @return  mixed  An array of the field names, or false if an error occurs.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function getFields()
+	public function getFields($reload = false)
 	{
 		static $cache = null;
 
-		if ($cache === null)
+		if ($cache === null || $reload)
 		{
 			// Lookup the fields for this table only once.
 			$name   = $this->_tbl;


### PR DESCRIPTION
#### Summary of Changes

Add ability to reload cached JTable fields
#### No built-in use cases

But they are exist.
